### PR TITLE
address warnings, add vector dep to application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,19 +5,19 @@ defmodule Polyline.Mixfile do
     [app: :polyline,
      version: "0.1.0",
      elixir: "~> 1.2",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :vector]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Hi @pkinney, I'm about to use this lib in production, but the way our deployment is currently built, it requires dependencies to be specified also as applications. I think this will be harmless for setups that may not require that, but critical for others as they will see an error like this:

```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function Vector.add/2 is undefined (module Vector is not available)
        Vector.add({2.5e-4, -6.0e-5}, {-71.16681, 42.34008})
```