### PR TITLE
fix calculating diffs on float coordinates

### DIFF
--- a/lib/polyline.ex
+++ b/lib/polyline.ex
@@ -37,23 +37,30 @@ defmodule Polyline do
       "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
   """
   def encode(coordinates, precision \\ @default_precision) do
-    elem(do_encode(coordinates, :math.pow(10, precision)), 0)
+    factor = :math.pow(10, precision)
+
+    rounded_coordinates =
+      Enum.map(coordinates, fn {x, y} ->
+        {round(x * factor), round(y * factor)}
+      end)
+
+    elem(do_encode(rounded_coordinates), 0)
   end
 
-  defp do_encode([], _), do: {"", nil}
+  defp do_encode([]), do: {"", nil}
 
-  defp do_encode([{x0, y0} | coordinates], factor) do
-    Enum.reduce(coordinates, encode_step({x0, y0}, {"", {0, 0}}, factor), fn t, acc ->
-      encode_step(t, acc, factor)
+  defp do_encode([{x0, y0} | coordinates]) do
+    Enum.reduce(coordinates, encode_step({x0, y0}, {"", {0, 0}}), fn t, acc ->
+      encode_step(t, acc)
     end)
   end
 
-  defp encode_step({x, y}, {acc, {x_prev, y_prev}}, factor) do
-    {acc <> encode_float(y - y_prev, factor) <> encode_float(x - x_prev, factor), {x, y}}
+  defp encode_step({x, y}, {acc, {x_prev, y_prev}}) do
+    {acc <> encode_int(y - y_prev) <> encode_int(x - x_prev), {x, y}}
   end
 
-  defp encode_float(x, factor) do
-    round(x * factor) <<< 1
+  defp encode_int(x) do
+    x <<< 1
     |> unsign
     |> collect_chars
     |> to_string

--- a/test/polyline_test.exs
+++ b/test/polyline_test.exs
@@ -61,6 +61,18 @@ defmodule PolylineTest do
     assert %Geo.LineString{coordinates: res} |> Geo.JSON.encode() |> Poison.encode!() == expected
   end
 
+  test "encode an over-precise string same way as reference implementation" do
+    # reference value is generated using following JS google maps API code:
+    # raw_coords = [[-87.650934, 41.875332], [-87.650938, 41.875336], [-87.650941, 41.87534]]
+    # path = raw_coords.map(function(coords){ return new google.maps.LatLng(coords[1], coords[0]) })
+    # google.maps.geometry.encoding.encodePath(path)
+    assert Polyline.encode([
+             {-87.650933, 41.875332},
+             {-87.650936, 41.875336},
+             {-87.650942, 41.875340}
+           ]) == "ywq~Fhi~uOA@??"
+  end
+
   test "encode a long string" do
     res =
       Path.join([".", "test", "fixtures", "long.geo.json"])


### PR DESCRIPTION
though official doc is not clear on the subject, reference [utility](https://developers.google.com/maps/documentation/utilities/polylineutility) implementation
as well as other implementations (such as ruby gem `polylines`) do round
before calculating diffs