### PR TITLE
Improve performance of decode function

### DIFF
--- a/lib/polyline.ex
+++ b/lib/polyline.ex
@@ -96,13 +96,14 @@ defmodule Polyline do
           {:cont, {[sign(next_one) / factor | values], remain}}
       end)
 
-    result =
-      Enum.reduce(Enum.chunk_every(Enum.reverse(terms), 2, 2, :discard), nil, fn
-        [y, x], nil -> [{x, y}]
-        [y, x], acc -> [Vector.add({x, y}, List.first(acc)) | acc]
-      end)
-
-    Enum.reverse(result)
+    terms
+    |> Enum.reverse()
+    |> Enum.chunk_every(2, 2, :discard)
+    |> Enum.reduce(nil, fn
+      [y, x], nil -> [{x, y}]
+      [y, x], acc -> [Vector.add({x, y}, List.first(acc)) | acc]
+    end)
+    |> Enum.reverse()
   end
 
   defp decode_next([head | []], shift), do: {decode_char(head, shift), ''}

--- a/lib/polyline.ex
+++ b/lib/polyline.ex
@@ -93,13 +93,16 @@ defmodule Polyline do
 
         _, {values, remain} ->
           {next_one, remain} = decode_next(remain, 0)
-          {:cont, {values ++ [sign(next_one) / factor], remain}}
+          {:cont, {[sign(next_one) / factor | values], remain}}
       end)
 
-    Enum.reduce(Enum.chunk_every(terms, 2, 2, :discard), nil, fn
-      [y, x], nil -> [{x, y}]
-      [y, x], acc -> acc ++ [Vector.add({x, y}, List.last(acc))]
-    end)
+    result =
+      Enum.reduce(Enum.chunk_every(Enum.reverse(terms), 2, 2, :discard), nil, fn
+        [y, x], nil -> [{x, y}]
+        [y, x], acc -> [Vector.add({x, y}, List.first(acc)) | acc]
+      end)
+
+    Enum.reverse(result)
   end
 
   defp decode_next([head | []], shift), do: {decode_char(head, shift), ''}


### PR DESCRIPTION
## Problem
Given a large polyline of about 160k bytes, the `decode` function behaves slowly due to its implementation. For example, 
 a simple benchmark using `:timer.tc:` for the current implementation vs the new in microseconds reveals the improvement:

```elixir
iex(55)> tCurrent
52948900
iex(56)> tNew
143184
```

One of the main problems is the usage of the operator `++` that performs a copy of the enum in order to preserve immutability due to the nature of the programming language.

It makes the algorithm slow, having complexity in the worst case of O(n^2) when in the loop, the `++` function has to copy the whole list. 

More info [here](https://erlang.org/doc/efficiency_guide/myths.html#myth--operator--++--is-always-bad)

## Solution
A better approach is to use the head-tail that is how the lists are built in Erlang + reverse approach, so we can reduce the complexity to O(n) 
