### PR TITLE
optimize decode

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Polyline.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :vector]]
+    [applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:
@@ -34,7 +34,6 @@ defmodule Polyline.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:vector, "~> 1.0"},
       {:earmark, "~> 1.2", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev},
       {:geo, "~> 3.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -25,5 +25,4 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "vector": {:hex, :vector, "1.1.0", "0789b5e00e9c551d8d5880acab9a8f44ed46690d083af397018bf0c7f30c1092", [:mix], [], "hexpm", "48b0a800ec88e55b12c689b09100e4c9ba41ea1befb459221c085a4e70040696"},
 }


### PR DESCRIPTION
Speedups:
- eliminating extra passes over data
- `reduce` instead of `reduce_while`
- remove `Vector.add` function call

```
CPU: Intel i7-8550U 1.80GHz
Elixir: 1.14.5-otp-26
Erlang 26.0

optimized (duration: 1.0 s)
benchmark name           iterations   average time
decode small polyline       1000000   1.13 µs/op
decode medium polyline       100000   12.60 µs/op
decode a large polyline        5000   421.46 µs/op

optimized (duration: 60.0 s)
benchmark name           iterations   average time
decode small polyline     100000000   1.19 µs/op
decode medium polyline     10000000   12.18 µs/op
decode a large polyline      500000   396.75 µs/op

vanilla (duration: 1.0 s)
benchmark name           iterations   average time
decode small polyline       1000000   1.66 µs/op
decode medium polyline       100000   23.95 µs/op
decode a large polyline        2000   891.73 µs/op

vanilla (duration: 60.0 s)
benchmark name           iterations   average time
decode small polyline     100000000   1.88 µs/op
decode medium polyline      5000000   26.50 µs/op
decode a large polyline      100000   930.61 µs/op
```